### PR TITLE
Nested drop downs

### DIFF
--- a/apper/Fusion360CommandBase.py
+++ b/apper/Fusion360CommandBase.py
@@ -58,7 +58,8 @@ class Fusion360CommandBase:
         self.custom_tab = False
 
         self.add_to_drop_down = options.get('add_to_drop_down', False)
-        self.drop_down_cmd_id_path = options.get('drop_down_cmd_id_path', ['Default_DD_CmdId'])
+        drop_down_cmd_id = options.get('drop_down_cmd_id', 'Default_DD_CmdId') # for backwards compatibility
+        self.drop_down_cmd_id_path = options.get('drop_down_cmd_id_path', drop_down_cmd_id)
         if isinstance(self.drop_down_cmd_id_path, str):
             self.drop_down_cmd_id_path = [self.drop_down_cmd_id_path]
         elif not (isinstance(self.drop_down_cmd_id_path, List) and len(self.drop_down_cmd_id_path) > 0):


### PR DESCRIPTION
Currently, the Fusion360CommandBase class will add a command to a dropdown control given the id. It will even auto-create a parent dropdown if it doesn't already exist. However, if the desired parent dropdown is nested within another dropdown, then there is no clean way to have the control created. One would have to override the on_run method which is not a clean design pattern.

One option to simplify this (IMO, not the best option) would be to break the on_run method into multiple methods and override a dropdown creation method. Instead, to maintain the spirit of the configuration options input, the **drop_down_cmd_id** option is extended to a list of ids representing the ancestry of the new component (i.e. a path in the tree structure of controls). The new option is aptly named **drop_down_cmd_id_path**. 

The **drop_down_cmd_id** option is still supported. If **drop_down_cmd_id_path** is provided in the options, then **drop_down_cmd_id** will be ignored. If not, then **drop_down_cmd_id** will be added to an empty list by default.

The on_run method has been updated to iterate over the parent ids in **drop_down_cmd_id_path**. If at any point a dropdown is not found for the current id, a new dropdown is created to be used as the target parent. Any remaining ids in the path are ignored.